### PR TITLE
QuestChecker and small updates

### DIFF
--- a/Hare_s_Blooming_Lace/Assets/Dialogues/Scripts/DialogueManager.cs
+++ b/Hare_s_Blooming_Lace/Assets/Dialogues/Scripts/DialogueManager.cs
@@ -19,11 +19,11 @@ public class DialogueManager : MonoBehaviour
     public float typingspeed = 0.2f;
     public Animator animator;
 
-    public float NextDialogueLineTime = 5f; 
+    public float NextDialogueLineTime = 5f;
     private bool isTyping = false;
 
     private float playAnimTime = 1.5f;
-    private float hideAnimTime = 1.5f; 
+    private float hideAnimTime = 1.5f;
     private Dialogue currentDialogue;
     private DialogueTrigger currentDialogueTrigger;
 
@@ -36,19 +36,25 @@ public class DialogueManager : MonoBehaviour
     // Если 1 метр в игре = 100 пикселям на Canvas
     private float scaleFactor = 100f;
 
+    // Новые переменные для ограничения движения по X
+    public float minX = -400f; // Установи нужные значения в инспекторе
+    public float maxX = 400f; // Установи нужные значения в инспекторе
+
 
     void LateUpdate()
     {
-        if (player != null )
+        if (player != null)
         {
-            Debug.Log("Player position: " + player.position.x);
-
             // Получаем текущую позицию Rect Transform
             Vector2 currentPosition = dialogueBoxRect.anchoredPosition;
 
             // Обновляем только координату X, масштабируя её
             float scaledX = player.position.x * scaleFactor;
-            currentPosition.x = scaledX;
+
+            // Ограничиваем X-координату, чтобы она не выходила за пределы
+            float clampedX = Mathf.Clamp(scaledX, minX, maxX);
+
+            currentPosition.x = clampedX;
 
             // Присваиваем обновлённую позицию, сохраняя Y
             dialogueBoxRect.anchoredPosition = currentPosition;
@@ -111,7 +117,7 @@ public class DialogueManager : MonoBehaviour
         }
 
         DialogueLine currentLine = lines.Dequeue();
-        
+
         PlayerIcon.enabled = false;
         NpcIcon.enabled = false;
         animator.Play("Line");
@@ -121,18 +127,18 @@ public class DialogueManager : MonoBehaviour
             if (PlayerIcon != null && currentLine.character.icon != null)
             {
                 PlayerIcon.sprite = currentLine.character.icon;
-                PlayerIcon.enabled = true; 
+                PlayerIcon.enabled = true;
             }
         }
-        else 
+        else
         {
             if (NpcIcon != null && currentLine.character.icon != null)
             {
                 NpcIcon.sprite = currentLine.character.NpcIcon;
-                NpcIcon.enabled = true; 
+                NpcIcon.enabled = true;
             }
         }
-        
+
 
         StopAllCoroutines();
         StartCoroutine(TypeSentence(currentLine));
@@ -140,16 +146,16 @@ public class DialogueManager : MonoBehaviour
 
     IEnumerator TypeSentence(DialogueLine dialogueLine)
     {
-        isTyping = true; 
+        isTyping = true;
         DialogueArea.text = "";
         foreach (char letter in dialogueLine.line.ToCharArray())
         {
             DialogueArea.text += letter;
             yield return new WaitForSeconds(typingspeed);
         }
-        isTyping = false; 
+        isTyping = false;
 
-        
+
         StartCoroutine(WaitForPlayerInputOrAutoAdvance());
     }
 
@@ -163,15 +169,15 @@ public class DialogueManager : MonoBehaviour
 
             if (Input.GetKeyDown(KeyCode.E))
             {
-                
+
                 if (!isTyping)
                 {
-                    
+
                     break;
                 }
             }
 
-            yield return null; 
+            yield return null;
         }
 
         DisplayNextDialogueLine();
@@ -198,7 +204,7 @@ public class DialogueManager : MonoBehaviour
 
         currentDialogue = null;
         currentDialogueTrigger = null;
-        DialogueArea.text= "";
+        DialogueArea.text = "";
     }
 
 }

--- a/Hare_s_Blooming_Lace/Assets/Quests.meta
+++ b/Hare_s_Blooming_Lace/Assets/Quests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 117193dee55a24649bea573c4e47159a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Hare_s_Blooming_Lace/Assets/Quests/Quest.cs
+++ b/Hare_s_Blooming_Lace/Assets/Quests/Quest.cs
@@ -1,0 +1,24 @@
+using UnityEngine;
+
+[System.Serializable]
+public class Quest
+{
+    public int id;
+    public string title;
+    [TextArea(3, 10)]
+    public string description;
+
+    public bool isActive = false; // Инициализируем в false по умолчанию
+    public bool isCompleted = false; // Инициализируем в false по умолчанию
+
+    public void Activate()
+    {
+        isActive = true;
+    }
+
+    public void Complete()
+    {
+        isCompleted = true;
+        isActive = false;
+    }
+}

--- a/Hare_s_Blooming_Lace/Assets/Quests/Quest.cs.meta
+++ b/Hare_s_Blooming_Lace/Assets/Quests/Quest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9ea630743cd379d43bc66f7eb0ac651a

--- a/Hare_s_Blooming_Lace/Assets/Quests/QuestChecker.cs
+++ b/Hare_s_Blooming_Lace/Assets/Quests/QuestChecker.cs
@@ -1,0 +1,61 @@
+using UnityEngine;
+
+public class QuestChecker : MonoBehaviour
+{
+    // ID квеста, который необходим для успеха
+    public int requiredQuestId;
+
+    // Массив объектов, которые будут активированы при успешной проверке
+    public GameObject[] OnSuccess;
+    // Массив объектов, которые будут активированы при неудачной проверке
+    public GameObject[] OnFailure;
+
+    private void OnTriggerEnter2D(Collider2D other)
+    {
+        if (other.CompareTag("Player"))
+        {
+            CheckQuestStatus();
+        }
+    }
+
+    public void CheckQuestStatus()
+    {
+        Debug.Log("QuestChecker: Начинаем проверку текущего квеста...");
+
+        if (QuestManager.instance == null)
+        {
+            Debug.LogError("QuestChecker: QuestManager не найден в сцене!");
+            return;
+        }
+
+        Quest currentQuest = QuestManager.instance.activeQuest;
+
+        // Если активного квеста нет, или его ID меньше требуемого
+        if (currentQuest == null || currentQuest.id < requiredQuestId)
+        {
+            Debug.Log($"QuestChecker: Неудача! Текущий квест (ID: {(currentQuest != null ? currentQuest.id : 0)}) меньше требуемого (ID: {requiredQuestId}).");
+
+            SetObjectsActive(OnSuccess, false);
+            SetObjectsActive(OnFailure, true);
+        }
+        // Если ID активного квеста равен или больше требуемого
+        else
+        {
+            Debug.Log($"QuestChecker: Успех! Текущий квест (ID: {currentQuest.id}) соответствует или превышает требуемый (ID: {requiredQuestId}).");
+
+            SetObjectsActive(OnSuccess, true);
+            SetObjectsActive(OnFailure, false);
+        }
+    }
+
+    private void SetObjectsActive(GameObject[] objects, bool isActive)
+    {
+        foreach (GameObject obj in objects)
+        {
+            if (obj != null)
+            {
+                obj.SetActive(isActive);
+            }
+        }
+    }
+}

--- a/Hare_s_Blooming_Lace/Assets/Quests/QuestChecker.cs.meta
+++ b/Hare_s_Blooming_Lace/Assets/Quests/QuestChecker.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 469c8a95ca7163642b38ea31fc40652e

--- a/Hare_s_Blooming_Lace/Assets/Quests/QuestManager.cs
+++ b/Hare_s_Blooming_Lace/Assets/Quests/QuestManager.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class QuestManager : MonoBehaviour
+{
+    public static QuestManager instance;
+
+    public List<Quest> allQuests;
+    public Quest activeQuest;
+
+    private void Awake()
+    {
+        if (instance == null)
+        {
+            instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+        else
+        {
+            Destroy(gameObject);
+        }
+    }
+
+    public void SetActiveQuest(int questId)
+    {
+        Quest newQuest = GetQuestById(questId);
+
+        if (newQuest != null && !newQuest.isCompleted)
+        {
+            // ƒеактивируем предыдущий квест, если он есть
+            if (activeQuest != null)
+            {
+                activeQuest.isActive = false;
+            }
+
+            activeQuest = newQuest;
+            activeQuest.Activate();
+            Debug.Log($" вест активирован: {activeQuest.title}");
+        }
+        else if (newQuest != null && newQuest.isCompleted)
+        {
+            Debug.LogWarning($" вест с ID {questId} уже завершен.");
+        }
+        else
+        {
+            Debug.LogError($" вест с ID {questId} не найден!");
+        }
+    }
+
+    public Quest GetQuestById(int questId)
+    {
+        foreach (Quest quest in allQuests)
+        {
+            if (quest.id == questId)
+            {
+                return quest;
+            }
+        }
+        return null;
+    }
+}

--- a/Hare_s_Blooming_Lace/Assets/Quests/QuestManager.cs.meta
+++ b/Hare_s_Blooming_Lace/Assets/Quests/QuestManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d3e22109d53ec224e9e77478b3fa1a01

--- a/Hare_s_Blooming_Lace/Assets/Scenes/Locations/Scripts/CameraScript.cs
+++ b/Hare_s_Blooming_Lace/Assets/Scenes/Locations/Scripts/CameraScript.cs
@@ -27,7 +27,6 @@ public class CameraScript : MonoBehaviour
             // Создаем новую позицию для камеры
             Vector3 targetPosition = new Vector3(Player.position.x, yOffset, zOffset);
 
-            // --- НОВАЯ ЛОГИКА ---
             // Проверяем, если расстояние слишком большое
             if (Vector3.Distance(transform.position, targetPosition) > teleportDistance)
             {

--- a/Hare_s_Blooming_Lace/Assets/Scenes/Locations/Village/Village.unity
+++ b/Hare_s_Blooming_Lace/Assets/Scenes/Locations/Village/Village.unity
@@ -542,7 +542,7 @@ GameObject:
   m_Component:
   - component: {fileID: 379794574}
   - component: {fileID: 379794573}
-  - component: {fileID: 379794572}
+  - component: {fileID: 379794575}
   m_Layer: 0
   m_Name: PreDarkForestEnter
   m_TagString: Untagged
@@ -550,25 +550,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &379794572
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 379794571}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ca478c21c7bea4040948b7facc5d491a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  targetSceneName: PreDarkForest
-  loadingSceneName: 
-  shouldTeleport: 0
-  targetPosition: {x: 0, y: 0}
-  transitionAnimator: {fileID: 201592918}
-  transitionDuration: 2.5
-  transitionInClipName: In
 --- !u!61 &379794573
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -629,8 +610,27 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 517801342}
+  - {fileID: 2076674089}
+  - {fileID: 891880780}
   m_Father: {fileID: 201592919}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &379794575
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 379794571}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 469c8a95ca7163642b38ea31fc40652e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  requiredQuestId: 1
+  OnSuccess:
+  - {fileID: 2076674088}
+  OnFailure:
+  - {fileID: 891880779}
 --- !u!1 &470546549
 GameObject:
   m_ObjectHideFlags: 0
@@ -1269,115 +1269,6 @@ SpriteRenderer:
   m_WasSpriteAssigned: 0
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!1001 &641957629
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 688823590041895667, guid: d724c944f30db184ab1b304c162c91fa, type: 3}
-      propertyPath: m_Enabled
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1539073197186299364, guid: d724c944f30db184ab1b304c162c91fa, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1539073197186299364, guid: d724c944f30db184ab1b304c162c91fa, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1539073197186299364, guid: d724c944f30db184ab1b304c162c91fa, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1539073197186299364, guid: d724c944f30db184ab1b304c162c91fa, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1539073197186299364, guid: d724c944f30db184ab1b304c162c91fa, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1539073197186299364, guid: d724c944f30db184ab1b304c162c91fa, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1539073197186299364, guid: d724c944f30db184ab1b304c162c91fa, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1539073197186299364, guid: d724c944f30db184ab1b304c162c91fa, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 1539073197186299364, guid: d724c944f30db184ab1b304c162c91fa, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1539073197186299364, guid: d724c944f30db184ab1b304c162c91fa, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1539073197186299364, guid: d724c944f30db184ab1b304c162c91fa, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1539073197186299364, guid: d724c944f30db184ab1b304c162c91fa, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1539073197186299364, guid: d724c944f30db184ab1b304c162c91fa, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1539073197186299364, guid: d724c944f30db184ab1b304c162c91fa, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1539073197186299364, guid: d724c944f30db184ab1b304c162c91fa, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1539073197186299364, guid: d724c944f30db184ab1b304c162c91fa, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: -58.4258
-      objectReference: {fileID: 0}
-    - target: {fileID: 1539073197186299364, guid: d724c944f30db184ab1b304c162c91fa, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 421
-      objectReference: {fileID: 0}
-    - target: {fileID: 1539073197186299364, guid: d724c944f30db184ab1b304c162c91fa, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1539073197186299364, guid: d724c944f30db184ab1b304c162c91fa, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1539073197186299364, guid: d724c944f30db184ab1b304c162c91fa, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6507492175072440191, guid: d724c944f30db184ab1b304c162c91fa, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -673
-      objectReference: {fileID: 0}
-    - target: {fileID: 6588320446500733663, guid: d724c944f30db184ab1b304c162c91fa, type: 3}
-      propertyPath: m_Name
-      value: HareDialogueBox
-      objectReference: {fileID: 0}
-    - target: {fileID: 6588320446500733663, guid: d724c944f30db184ab1b304c162c91fa, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: d724c944f30db184ab1b304c162c91fa, type: 3}
 --- !u!1 &680708027
 GameObject:
   m_ObjectHideFlags: 0
@@ -1597,93 +1488,6 @@ SpriteRenderer:
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 0
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!1 &756373074
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 756373075}
-  - component: {fileID: 756373076}
-  m_Layer: 0
-  m_Name: CharacterIcon
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &756373075
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 756373074}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1325466243}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &756373076
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 756373074}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
 --- !u!1 &757833449
@@ -2106,6 +1910,107 @@ SpriteRenderer:
   m_WasSpriteAssigned: 0
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1 &891880779
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 891880780}
+  - component: {fileID: 891880783}
+  - component: {fileID: 891880781}
+  m_Layer: 0
+  m_Name: Monolog
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &891880780
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 891880779}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 1.79, y: 2.11111, z: 2}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 379794574}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &891880781
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 891880779}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cfc5e92dd6b2b9a4f92c3202c18a81d1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  dialogues:
+  - dialoguelines:
+    - character:
+        icon: {fileID: 21300000, guid: e1f48077f14fd024db24879910a6c260, type: 3}
+        NpcIcon: {fileID: 21300000, guid: e1f48077f14fd024db24879910a6c260, type: 3}
+      isPlayer: 1
+      line: The village is in the other direction.
+    Player: {fileID: 2051834058}
+    Npc: {fileID: 0}
+  interactKey: 101
+--- !u!61 &891880783
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 891880779}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: -1.6031795, y: -2.6187778}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 4.922471, y: 10.850602}
+  m_EdgeRadius: 0
 --- !u!1 &917927146
 GameObject:
   m_ObjectHideFlags: 0
@@ -2723,93 +2628,6 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!1 &1077616003
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1077616004}
-  - component: {fileID: 1077616005}
-  m_Layer: 0
-  m_Name: Body
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1077616004
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1077616003}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -13.99, y: 7.35, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1325466243}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &1077616005
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1077616003}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: d44023632f76dd149a4346bb3be68769, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
 --- !u!1 &1201366032
 GameObject:
   m_ObjectHideFlags: 0
@@ -3092,7 +2910,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.8200001, y: 0}
   m_AnchorMax: {x: 0.8200001, y: 0}
-  m_AnchoredPosition: {x: 970.80005, y: -157.21986}
+  m_AnchoredPosition: {x: 841, y: -157.21986}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 1, y: 0}
 --- !u!114 &1271056391
@@ -3147,119 +2965,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1271056389}
   m_CullTransparentMesh: 1
---- !u!1 &1325466240
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1325466243}
-  - component: {fileID: 1325466242}
-  - component: {fileID: 1325466241}
-  m_Layer: 0
-  m_Name: Dialogue
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!114 &1325466241
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1325466240}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cb3141da7cb98c94c86ae87eecaef1f6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  PlayerIcon: {fileID: 0}
-  NpcIcon: {fileID: 0}
-  IconPosition: {x: 0, y: 0}
-  DialogueArea: {fileID: 0}
-  isDialogueActive: 0
-  typingspeed: 0.2
-  animator: {fileID: 0}
-  NextDialogueLineTime: 5
-  dialogueBoxRect: {fileID: 0}
-  player: {fileID: 0}
---- !u!212 &1325466242
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1325466240}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 0
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!4 &1325466243
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1325466240}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -53.41294, y: -9.86198, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1077616004}
-  - {fileID: 756373075}
-  - {fileID: 2133662194}
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1365262608
 GameObject:
   m_ObjectHideFlags: 0
@@ -3663,6 +3368,8 @@ MonoBehaviour:
   NextDialogueLineTime: 5
   dialogueBoxRect: {fileID: 1507967010}
   player: {fileID: 471344269}
+  minX: -6677.98
+  maxX: 6677.98
 --- !u!1 &1518519868
 GameObject:
   m_ObjectHideFlags: 0
@@ -3848,6 +3555,67 @@ Transform:
   m_Children:
   - {fileID: 470546553}
   m_Father: {fileID: 201592919}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1635243356
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1635243358}
+  - component: {fileID: 1635243357}
+  m_Layer: 0
+  m_Name: QuestManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1635243357
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1635243356}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d3e22109d53ec224e9e77478b3fa1a01, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  allQuests:
+  - id: 0
+    title: Go Home
+    description: bla bla
+    isActive: 1
+    isCompleted: 0
+  - id: 1
+    title: Ask somebody around
+    description: bla bla
+    isActive: 0
+    isCompleted: 0
+  activeQuest:
+    id: 0
+    title: 
+    description: 
+    isActive: 0
+    isCompleted: 0
+--- !u!4 &1635243358
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1635243356}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -42.16533, y: 0.00496, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1653143986
 GameObject:
@@ -4764,7 +4532,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1974427042}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -5092,7 +4860,7 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!1 &2133662193
+--- !u!1 &2076674088
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -5100,37 +4868,58 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2133662194}
-  - component: {fileID: 2133662195}
+  - component: {fileID: 2076674089}
+  - component: {fileID: 2076674092}
+  - component: {fileID: 2076674091}
+  - component: {fileID: 2076674090}
   m_Layer: 0
-  m_Name: NpcIcon
+  m_Name: Enter
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2133662194
+--- !u!4 &2076674089
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2133662193}
+  m_GameObject: {fileID: 2076674088}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 1.79, y: 2.11111, z: 2}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1325466243}
+  m_Father: {fileID: 379794574}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &2133662195
+--- !u!114 &2076674090
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2076674088}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ca478c21c7bea4040948b7facc5d491a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  targetSceneName: PreDarkForest
+  loadingSceneName: 
+  shouldTeleport: 0
+  targetPosition: {x: 0, y: 0}
+  transitionAnimator: {fileID: 201592918}
+  transitionDuration: 2.5
+  transitionInClipName: In
+--- !u!212 &2076674091
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2133662193}
+  m_GameObject: {fileID: 2076674088}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -5167,8 +4956,8 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_SortingOrder: -2
+  m_Sprite: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -5176,9 +4965,55 @@ SpriteRenderer:
   m_Size: {x: 1, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
+  m_WasSpriteAssigned: 0
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!61 &2076674092
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2076674088}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: -1.6031795, y: -2.6187778}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 4.922471, y: 10.850602}
+  m_EdgeRadius: 0
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -5186,6 +5021,5 @@ SceneRoots:
   - {fileID: 1241797180}
   - {fileID: 1473147931}
   - {fileID: 201592919}
+  - {fileID: 1635243358}
   - {fileID: 1201366035}
-  - {fileID: 1325466243}
-  - {fileID: 641957629}


### PR DESCRIPTION
This component allows for scene-specific checks against the player's active quest progress. It enables/disables game objects based on a required quest ID, providing a flexible way to gate content like doors or dialogue.
- also , added limits for dialogue box and cimmit small update in QuestManager and Quest scripts